### PR TITLE
Fix modern browsers support

### DIFF
--- a/app/javascript/components/video.js
+++ b/app/javascript/components/video.js
@@ -37,12 +37,7 @@ const showVideo = () =>  {
        }
     };
     const successCallback = stream => {
-      if (navigator.mozGetUserMedia) {
-        video.mozSrcObject = stream;
-      } else {
-        const vendorURL = window.URL || window.webkitURL;
-        video.srcObject = stream;
-      }
+      video.srcObject = stream;
       video.play();
     }
     const errorCallback = err => {

--- a/app/javascript/components/video.js
+++ b/app/javascript/components/video.js
@@ -1,29 +1,3 @@
-const fallBackVideo = () => {
-  let aspectRatio = (window.innerHeight - 132) / window.innerWidth;
-  navigator.getMedia(
-    {
-      audio: false,
-      video: {
-          aspectRatio: 1 / aspectRatio
-        }
-    },
-    (stream) => {
-      if (navigator.mozGetUserMedia) {
-
-        video.mozSrcObject = stream;
-      } else {
-        const vendorURL = window.URL || window.webkitURL;
-        video.srcObject = stream;
-      }
-      video.play();
-    },
-    function(err) {
-      console.log("An error occured! " + err);
-    }
-  );
-
-};
-
 const defineDimensions = (height, width) => {
   if (height > 360) {
     const ratio = height / 360;
@@ -59,7 +33,7 @@ const showVideo = () =>  {
       {
         audio: false,
         video: {
-          facingMode: { exact: "environment" },
+          facingMode: { ideal: "environment" },
           aspectRatio: aspectRatio
          }
       },
@@ -74,8 +48,7 @@ const showVideo = () =>  {
         video.play();
       },
       function(err) {
-        console.log("An error occured! " + err);
-        fallBackVideo();
+        console.log("An error occured! ", err);
       }
     );
 

--- a/app/javascript/components/video.js
+++ b/app/javascript/components/video.js
@@ -36,13 +36,20 @@ const showVideo = () =>  {
       console.log("An error occured! ", err);
     }
 
-    navigator.getUserMediaForOldBrowsers = (
-      navigator.getUserMedia ||
-      navigator.webkitGetUserMedia ||
-      navigator.mozGetUserMedia ||
-      navigator.msGetUserMedia
-    );
-    navigator.getUserMediaForOldBrowsers(constraints, successCallback, errorCallback);
+    if (navigator.mediaDevices.getUserMedia) {
+      navigator.mediaDevices.getUserMedia(constraints).
+        then(successCallback).
+        catch(errorCallback);
+    } else {
+      console.log("using fallback polyfill for old browsers")
+      navigator.getUserMediaForOldBrowsers = (
+        navigator.getUserMedia ||
+        navigator.webkitGetUserMedia ||
+        navigator.mozGetUserMedia ||
+        navigator.msGetUserMedia
+      );
+      navigator.getUserMediaForOldBrowsers(constraints, successCallback, errorCallback);
+    }
 
     video.addEventListener('canplay', function(ev){
       if (!streaming) {

--- a/app/javascript/components/video.js
+++ b/app/javascript/components/video.js
@@ -29,28 +29,26 @@ const showVideo = () =>  {
 
     let aspectRatio = (window.innerHeight - 132) / window.innerWidth;
 
-    navigator.getMedia(
-      {
-        audio: false,
-        video: {
-          facingMode: { ideal: "environment" },
-          aspectRatio: aspectRatio
-         }
-      },
-      (stream) => {
-        if (navigator.mozGetUserMedia) {
-
-          video.mozSrcObject = stream;
-        } else {
-          const vendorURL = window.URL || window.webkitURL;
-          video.srcObject = stream;
-        }
-        video.play();
-      },
-      function(err) {
-        console.log("An error occured! ", err);
+    const constraints = {
+      audio: false,
+      video: {
+        facingMode: { ideal: "environment" },
+        aspectRatio: aspectRatio
+       }
+    };
+    const successCallback = stream => {
+      if (navigator.mozGetUserMedia) {
+        video.mozSrcObject = stream;
+      } else {
+        const vendorURL = window.URL || window.webkitURL;
+        video.srcObject = stream;
       }
-    );
+      video.play();
+    }
+    const errorCallback = err => {
+      console.log("An error occured! ", err);
+    }
+    navigator.getMedia(constraints, successCallback, errorCallback);
 
     video.addEventListener('canplay', function(ev){
       if (!streaming) {

--- a/app/javascript/components/video.js
+++ b/app/javascript/components/video.js
@@ -20,15 +20,7 @@ const showVideo = () =>  {
     let width = 200;
     let height = 0;
     const snapVideo = document.querySelector('#snap_video');
-
-    navigator.getMedia = ( navigator.getUserMedia ||
-                           navigator.webkitGetUserMedia ||
-                           navigator.mozGetUserMedia ||
-                           navigator.msGetUserMedia ||
-                           navigator.MediaDevices.getUserMedia);
-
     let aspectRatio = (window.innerHeight - 132) / window.innerWidth;
-
     const constraints = {
       audio: false,
       video: {
@@ -43,7 +35,14 @@ const showVideo = () =>  {
     const errorCallback = err => {
       console.log("An error occured! ", err);
     }
-    navigator.getMedia(constraints, successCallback, errorCallback);
+
+    navigator.getUserMediaForOldBrowsers = (
+      navigator.getUserMedia ||
+      navigator.webkitGetUserMedia ||
+      navigator.mozGetUserMedia ||
+      navigator.msGetUserMedia
+    );
+    navigator.getUserMediaForOldBrowsers(constraints, successCallback, errorCallback);
 
     video.addEventListener('canplay', function(ev){
       if (!streaming) {


### PR DESCRIPTION
this PR simplifies the use of getUserMedia and favors using the new `navigator.mediaDevices.getUserMedia` rather than the deprecated `navigator.getUserMedia`. This fixes the camera at least for some iOS devices.

The PR should be read commit by commit, I splitted them up meaningfully so it's easy to read.

- I first refactor a bit, and remove the current fallback for desktop browsers by loosening the constraints so that it works for both devices with a single call
- I then proceed to add a condition and use the new API first but leave the fallback for the existing deprecated one.